### PR TITLE
Automatically generate script and folder keys

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,6 @@ view the ``examples/froge directory`` for a generated pymodd project
 
     class EverySecond(Script):
         def _build(self):
-            self.key = 'P8MwXcSxq7'
             self.triggers = [Trigger.EVERY_SECOND]
             self.actions = [
                 if_else((NumberOfUnitsOfUnitType(UnitTypes.FROG) < 5), [

--- a/examples/froge/entity_scripts.py
+++ b/examples/froge/entity_scripts.py
@@ -16,7 +16,6 @@ class Pooper(EntityScripts):
 
 	class UseItem(Script):
 		def _build(self):
-			self.key = 'umIqJLd7De'
 			self.triggers = []
 			self.actions = [
 				use_item_continuously_until_stopped(ItemCurrentlyHeldByUnit(ThisEntity())),
@@ -25,7 +24,6 @@ class Pooper(EntityScripts):
 
 	class StopUsingItem(Script):
 		def _build(self):
-			self.key = 'OJ9Po4VSQg'
 			self.triggers = []
 			self.actions = [
 				stop_using_item(ItemCurrentlyHeldByUnit(ThisEntity())),
@@ -43,7 +41,6 @@ class Frog(EntityScripts):
 
 	class NewScript(Script):
 		def _build(self):
-			self.key = 'XUAEBhSryo'
 			self.triggers = []
 			self.actions = [
 				comment('wdwadawd'),

--- a/examples/froge/scripts.py
+++ b/examples/froge/scripts.py
@@ -7,7 +7,6 @@ from game_variables import *
 
 class Initialize(Script):
 	def _build(self):
-		self.key = 'initialize'
 		self.triggers = [Trigger.GAME_START]
 		self.actions = [
 			assign_player_to_player_type(Variables.AI, PlayerTypes.AI),
@@ -17,7 +16,6 @@ class Initialize(Script):
 
 class PlayerJoins(Script):
 	def _build(self):
-		self.key = 'playerJoinsGame'
 		self.triggers = [Trigger.PLAYER_JOINS_GAME]
 		self.actions = [
 			create_unit_for_player_at_position_with_rotation(UnitTypes.POOPER, LastTriggeringPlayer(), RandomPositionInRegion(EntireMapRegion()), 0),
@@ -29,7 +27,6 @@ class PlayerJoins(Script):
 
 class PlayerLeaves(Script):
 	def _build(self):
-		self.key = 'playerLeavesGame'
 		self.triggers = [Trigger.PLAYER_LEAVES_GAME]
 		self.actions = [
 			for_all_units_in(AllUnitsOwnedByPlayer(LastTriggeringPlayer()), [
@@ -42,7 +39,6 @@ class PlayerLeaves(Script):
 
 class EverySecond(Script):
 	def _build(self):
-		self.key = 'P8MwXcSxq7'
 		self.triggers = [Trigger.EVERY_SECOND]
 		self.actions = [
 			if_else((NumberOfUnitsOfUnitType(UnitTypes.FROG) < 5), [
@@ -70,7 +66,6 @@ class EverySecond(Script):
 
 class WhenAUnitsAttributeBecomes0OrLess(Script):
 	def _build(self):
-		self.key = 'CE0PBg1VWG'
 		self.triggers = [Trigger.UNIT_ATTRIBUTE_BECOMES_ZERO]
 		self.actions = [
 			if_else((AttributeTypeOfAttribute(TriggeringAttribute()) == AttributeTypes.HEALTH), [
@@ -146,7 +141,6 @@ class WhenAUnitsAttributeBecomes0OrLess(Script):
 
 class OpenShop(Script):
 	def _build(self):
-		self.key = '5BUXtByxVf'
 		self.triggers = []
 		self.actions = [
 			open_shop_for_player(Shops.FROGE_SHOP, OwnerOfEntity(LastCastingUnit())),

--- a/examples/froge/scripts.py
+++ b/examples/froge/scripts.py
@@ -68,7 +68,7 @@ class WhenAUnitsAttributeBecomes0OrLess(Script):
 	def _build(self):
 		self.triggers = [Trigger.UNIT_ATTRIBUTE_BECOMES_ZERO]
 		self.actions = [
-			if_else((AttributeTypeOfAttribute(TriggeringAttribute()) == AttributeTypes.HEALTH), [
+			if_else((AttributeTypeOfAttribute(LastTriggeringAttribute()) == AttributeTypes.HEALTH), [
 				if_else((PlayerTypeOfPlayer(OwnerOfEntity(LastTriggeringUnit())) == PlayerTypes.PLAYER), [
 					set_entity_attribute(AttributeTypes.HEALTH, LastTriggeringUnit(), AttributeMaxOfEntity(AttributeTypes.HEALTH, LastTriggeringUnit())),
 					set_entity_variable(EntityVariables.TARGET_UNIT, LastTriggeringUnit(), Undefined()),
@@ -88,7 +88,7 @@ class WhenAUnitsAttributeBecomes0OrLess(Script):
 				]),
 				
 			], [
-				if_else((AttributeTypeOfAttribute(TriggeringAttribute()) == AttributeTypes.MOVE), [
+				if_else((AttributeTypeOfAttribute(LastTriggeringAttribute()) == AttributeTypes.MOVE), [
 					set_entity_variable(EntityVariables.TARGET_UNIT, LastTriggeringUnit(), Undefined()),
 					for_all_entities_in(AllEntitiesInRegion(DynamicRegion(XCoordinateOfPosition(PositionOfEntity(LastTriggeringUnit())) - (ValueOfEntityVariable(EntityVariables.SENSOR_RADIUS, LastTriggeringUnit()) / 2), YCoordinateOfPosition(PositionOfEntity(LastTriggeringUnit())) - (ValueOfEntityVariable(EntityVariables.SENSOR_RADIUS, LastTriggeringUnit()) / 2), ValueOfEntityVariable(EntityVariables.SENSOR_RADIUS, LastTriggeringUnit()), ValueOfEntityVariable(EntityVariables.SENSOR_RADIUS, LastTriggeringUnit()))), [
 						if_else((PlayerTypeOfPlayer(OwnerOfEntity(SelectedEntity())) == PlayerTypes.PLAYER), [

--- a/pymodd/actions.py
+++ b/pymodd/actions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import functools
 
 from .functions import Condition, Number, String
-from .script import Base, to_dict
+from .script import Script, to_dict
 
 
 def action(func):
@@ -378,10 +378,10 @@ def return_loop(comment=None, disabled=False, run_on_client=False):
 
 
 @action
-def run_script(script_name, comment=None, disabled=False, run_on_client=False):
+def run_script(script: Script, comment=None, disabled=False, run_on_client=False):
     return {
         'type': 'runScript',
-        'scriptName': to_dict(script_name),
+        'scriptName': to_dict(script.key),
     }
 
 

--- a/pymodd/functions.py
+++ b/pymodd/functions.py
@@ -365,7 +365,7 @@ class SelectedItem(Item):
         self.options = {}
 
 
-class TriggeringItem(Item):
+class LastTriggeringItem(Item):
     def __init__(self):
         self.function = 'getTriggeringItem'
         self.options = {}
@@ -553,7 +553,7 @@ class Attribute(Function):
     pass
 
 
-class TriggeringAttribute(Attribute):
+class LastTriggeringAttribute(Attribute):
     def __init__(self):
         self.function = 'getTriggeringAttribute'
         self.options = {}
@@ -576,7 +576,7 @@ class SensorOfUnit(Sensor):
         }
 
 
-class TriggeringSensor(Sensor):
+class LastTriggeringSensor(Sensor):
     def __init__(self):
         self.function = 'getTriggeringSensor'
         self.options = {}

--- a/pymodd/script.py
+++ b/pymodd/script.py
@@ -223,6 +223,10 @@ class Trigger(Enum):
     AD_PLAY_FAILED = 'adPlayFailed'
     AD_PLAY_BLOCKED = 'adPlayBlocked'
 
+    SEND_COINS_SUCCESS = 'sendCoinsSuccess'
+    COIN_SEND_FAILURE_DUE_TO_DAILY_LIMIT = 'coinSendFailureDueToDailyLimit'
+    COIN_SEND_FAILURE_DUE_TO_INSUFFICIENT_COINS = 'coinSendFailureDueToInsufficientCoins'
+
 
 class UiTarget(Enum):
     TOP = 'top'

--- a/pymodd/script.py
+++ b/pymodd/script.py
@@ -1,5 +1,6 @@
 import json
-import os
+import random
+import string
 from enum import Enum
 
 from caseconverter import camelcase, snakecase
@@ -95,7 +96,7 @@ class Folder(File):
     def __init__(self, name, scripts: list):
         super().__init__()
         self.name = name
-        self.key = key_from_name(self.name)
+        self.key = generate_random_key()
         self.scripts = scripts
         # set position of scripts inside the folder
         for i, script in enumerate(scripts):
@@ -112,10 +113,17 @@ class Folder(File):
 
 
 class Script(File):
+    _class_to_key = {}
+
+    def __new__(cls, *args, **kwargs):
+        if cls._class_to_key.get(cls, None) is None:
+            cls._class_to_key[cls] = generate_random_key()
+        return super(Script, cls).__new__(cls, *args, **kwargs)
+
     def __init__(self):
         super().__init__()
         self.name = snakecase(self.__class__.__name__).replace('_', ' ')
-        self.key = key_from_name(self.name)
+        self.key = Script._class_to_key[self.__class__]
         self.triggers = []
         self.actions = []
 
@@ -135,8 +143,8 @@ class Script(File):
         }
 
 
-def key_from_name(name):
-    return snakecase(name)
+def generate_random_key():
+    return ''.join(random.choices(string.ascii_letters + string.digits, k=10))
 
 
 def to_dict(obj):

--- a/src/game_data/directory.rs
+++ b/src/game_data/directory.rs
@@ -2,7 +2,8 @@ use heck::ToPascalCase;
 use serde_json::{map::Values, Map, Value};
 
 use crate::project_generator::utils::{
-    is_valid_class_name, to_pymodd_maps::TRIGGERS_TO_PYMODD_ENUM,
+    is_valid_class_name, iterators::directory_iterator::DirectoryIterItem,
+    to_pymodd_maps::TRIGGERS_TO_PYMODD_ENUM,
 };
 
 use super::actions::{self, Action};
@@ -67,6 +68,14 @@ impl Directory {
 
     pub fn is_empty(&self) -> bool {
         self.children.is_empty()
+    }
+
+    pub fn find_item_with_key(&self, key: &str) -> Option<DirectoryIterItem> {
+        self.iter_flattened().find(|item| match item {
+            DirectoryIterItem::StartOfDirectory(dir) => dir.key == key,
+            DirectoryIterItem::Script(script) => script.key == key,
+            _ => false,
+        })
     }
 }
 
@@ -177,7 +186,7 @@ mod tests {
     use super::filter_out_children_of_parent;
 
     impl Directory {
-        fn new(name: &str, key: &str, children: Vec<DirectoryItem>) -> Directory {
+        pub fn new(name: &str, key: &str, children: Vec<DirectoryItem>) -> Directory {
             Directory {
                 name: name.to_string(),
                 key: key.to_string(),

--- a/src/project_generator/entity_scripts_file.rs
+++ b/src/project_generator/entity_scripts_file.rs
@@ -18,8 +18,10 @@ impl EntityScriptsFile {
             from pymodd.script import EntityScripts, Folder, Script, Trigger, UiTarget, Flip\n\n\
             from game_variables import *\n\n\n"
         );
-        let scripts_class_content_builder =
-            ScriptsContentBuilder::new(&game_data.categories_to_variables);
+        let scripts_class_content_builder = ScriptsContentBuilder::new(
+            &game_data.categories_to_variables,
+            &game_data.root_directory,
+        );
 
         game_data
             .categories_to_entity_types

--- a/src/project_generator/scripts_file.rs
+++ b/src/project_generator/scripts_file.rs
@@ -377,7 +377,7 @@ mod tests {
                 .as_array()
                 .unwrap()
             )),
-            "use_item_continuously_until_stopped(TriggeringItem(), comment='hi!', disabled=True, run_on_client=True),\n"
+            "use_item_continuously_until_stopped(LastTriggeringItem(), comment='hi!', disabled=True, run_on_client=True),\n"
         )
     }
 

--- a/src/project_generator/scripts_file.rs
+++ b/src/project_generator/scripts_file.rs
@@ -29,7 +29,10 @@ impl ScriptsFile {
         );
         content.add(&build_directory_content(
             &game_data.root_directory,
-            &ScriptsContentBuilder::new(&game_data.categories_to_variables),
+            &ScriptsContentBuilder::new(
+                &game_data.categories_to_variables,
+                &game_data.root_directory,
+            ),
         ))
     }
 }
@@ -62,21 +65,25 @@ pub fn build_directory_content(
 
 pub struct ScriptsContentBuilder<'a> {
     categories_to_variables: &'a CategoriesToVariables,
+    root_directory: &'a Directory,
 }
 
 impl<'a> ScriptsContentBuilder<'a> {
-    pub fn new(categories_to_variables: &'a CategoriesToVariables) -> ScriptsContentBuilder<'a> {
+    pub fn new(
+        categories_to_variables: &'a CategoriesToVariables,
+        root_directory: &'a Directory,
+    ) -> ScriptsContentBuilder<'a> {
         ScriptsContentBuilder {
             categories_to_variables,
+            root_directory,
         }
     }
 
     pub fn build_script_content(&self, script: &Script) -> String {
-        let (class_name, script_key): (String, &str) = (script.pymodd_class_name(), &script.key);
+        let class_name = script.pymodd_class_name();
         format!(
             "class {class_name}(Script):\n\
             \tdef _build(self):\n\
-                \t\tself.key = '{script_key}'\n\
                 \t\tself.triggers = [{}]\n\
                 \t\tself.actions = [\n\
                 {}\
@@ -202,6 +209,16 @@ impl<'a> ScriptsContentBuilder<'a> {
             | ArgumentValueIterItem::Calculation(operation) => {
                 self.build_operation_content(&operation)
             }
+            ArgumentValueIterItem::ScriptKey(key) => {
+                let item_with_key = self.root_directory.find_item_with_key(&key);
+                if item_with_key.is_some() {
+                    if let DirectoryIterItem::Script(script) = item_with_key.unwrap() {
+                        // run_script action accepts Script objects, not keys
+                        return format!("{}()", script.pymodd_class_name());
+                    }
+                }
+                String::from("None")
+            }
             ArgumentValueIterItem::FunctionEnd => String::from(")"),
         }
     }
@@ -275,7 +292,7 @@ mod tests {
 
     use crate::game_data::{
         actions::parse_actions,
-        directory::Script,
+        directory::{Directory, DirectoryItem, Script},
         variable_categories::{CategoriesToVariables, Variable},
     };
 
@@ -284,17 +301,19 @@ mod tests {
     #[test]
     fn script_content() {
         assert_eq!(
-            ScriptsContentBuilder::new(&CategoriesToVariables::new(HashMap::new()))
-                .build_script_content(&Script::new(
-                    "initialize",
-                    "WI31HDK",
-                    vec!["gameStart"],
-                    Vec::new()
-                )),
+            ScriptsContentBuilder::new(
+                &CategoriesToVariables::new(HashMap::new()),
+                &Directory::new("root", "null", Vec::new())
+            )
+            .build_script_content(&Script::new(
+                "initialize",
+                "WI31HDK",
+                vec!["gameStart"],
+                Vec::new()
+            )),
             String::from(format!(
                 "class Initialize(Script):\n\
                     \tdef _build(self):\n\
-                        \t\tself.key = 'WI31HDK'\n\
                         \t\tself.triggers = [Trigger.GAME_START]\n\
                         \t\tself.actions = [\n\
                         \t\t\t\n\
@@ -306,10 +325,13 @@ mod tests {
     #[test]
     fn parse_action_with_variable_into_pymodd() {
         assert_eq!(
-            ScriptsContentBuilder::new(&CategoriesToVariables::new(HashMap::from([(
-                "shops",
-                vec![Variable::new("OJbEQyc7is", "WEAPONS", None)]
-            )])))
+            ScriptsContentBuilder::new(
+                &CategoriesToVariables::new(HashMap::from([(
+                    "shops",
+                    vec![Variable::new("OJbEQyc7is", "WEAPONS", None)]
+                )])),
+                &Directory::new("root", "null", Vec::new())
+            )
             .build_actions_content(&parse_actions(
                 &json!([
                     {
@@ -336,40 +358,48 @@ mod tests {
     #[test]
     fn parse_action_with_optional_arguments_into_pymodd() {
         assert_eq!(
-            ScriptsContentBuilder::new(&CategoriesToVariables::new(HashMap::new()))
-                .build_actions_content(&parse_actions(
-                    &json!([
-                        {
-                            "type": "runScript",
-                            "scriptName": "fjw24WdJ",
-                            "comment": "hi!",
-                            "runOnClient": true,
-                            "disabled": true,
-                        }
-                    ])
-                    .as_array()
-                    .unwrap()
-                )),
-            "run_script('fjw24WdJ', comment='hi!', disabled=True, run_on_client=True),\n"
+            ScriptsContentBuilder::new(
+                &CategoriesToVariables::new(HashMap::new()),
+                &Directory::new("root", "null", Vec::new())
+            )
+            .build_actions_content(&parse_actions(
+                &json!([
+                    {
+                        "type": "startUsingItem",
+                        "entity": {
+                            "function": "getTriggeringItem"
+                        },
+                        "comment": "hi!",
+                        "runOnClient": true,
+                        "disabled": true,
+                    }
+                ])
+                .as_array()
+                .unwrap()
+            )),
+            "use_item_continuously_until_stopped(TriggeringItem(), comment='hi!', disabled=True, run_on_client=True),\n"
         )
     }
 
     #[test]
     fn parse_action_with_only_optional_arguments_into_pymodd() {
         assert_eq!(
-            ScriptsContentBuilder::new(&CategoriesToVariables::new(HashMap::new()))
-                .build_actions_content(&parse_actions(
-                    &json!([
-                        {
-                            "type": "return",
-                            "comment": "hi!",
-                            "runOnClient": true,
-                            "disabled": false,
-                        }
-                    ])
-                    .as_array()
-                    .unwrap()
-                )),
+            ScriptsContentBuilder::new(
+                &CategoriesToVariables::new(HashMap::new()),
+                &Directory::new("root", "null", Vec::new())
+            )
+            .build_actions_content(&parse_actions(
+                &json!([
+                    {
+                        "type": "return",
+                        "comment": "hi!",
+                        "runOnClient": true,
+                        "disabled": false,
+                    }
+                ])
+                .as_array()
+                .unwrap()
+            )),
             "return_loop(comment='hi!', run_on_client=True),\n"
         )
     }
@@ -377,18 +407,21 @@ mod tests {
     #[test]
     fn parse_action_with_constant_into_pymodd() {
         assert_eq!(
-            ScriptsContentBuilder::new(&CategoriesToVariables::new(HashMap::new()))
-                .build_actions_content(&parse_actions(
-                    &json!([
-                        {
-                            "type": "updateUiTextForEveryone",
-                            "target": "top",
-                            "value": "Hello!"
-                        }
-                    ])
-                    .as_array()
-                    .unwrap()
-                )),
+            ScriptsContentBuilder::new(
+                &CategoriesToVariables::new(HashMap::new()),
+                &Directory::new("root", "null", Vec::new())
+            )
+            .build_actions_content(&parse_actions(
+                &json!([
+                    {
+                        "type": "updateUiTextForEveryone",
+                        "target": "top",
+                        "value": "Hello!"
+                    }
+                ])
+                .as_array()
+                .unwrap()
+            )),
             "update_ui_text_for_everyone(UiTarget.TOP, 'Hello!'),\n"
         )
     }
@@ -396,17 +429,20 @@ mod tests {
     #[test]
     fn parse_comment_action_into_pymodd() {
         assert_eq!(
-            ScriptsContentBuilder::new(&CategoriesToVariables::new(HashMap::new()))
-                .build_actions_content(&parse_actions(
-                    &json!([
-                        {
-                            "type": "comment",
-                            "comment": "hey there",
-                        }
-                    ])
-                    .as_array()
-                    .unwrap()
-                )),
+            ScriptsContentBuilder::new(
+                &CategoriesToVariables::new(HashMap::new()),
+                &Directory::new("root", "null", Vec::new())
+            )
+            .build_actions_content(&parse_actions(
+                &json!([
+                    {
+                        "type": "comment",
+                        "comment": "hey there",
+                    }
+                ])
+                .as_array()
+                .unwrap()
+            )),
             "comment('hey there'),\n"
         );
     }
@@ -414,7 +450,10 @@ mod tests {
     #[test]
     fn parse_nested_calculations_into_pymodd() {
         assert_eq!(
-            ScriptsContentBuilder::new(&CategoriesToVariables::new(HashMap::new()))
+            ScriptsContentBuilder::new(
+                &CategoriesToVariables::new(HashMap::new()),
+                &Directory::new("root", "null", Vec::new())
+            )
                 .build_actions_content(&parse_actions(
                     &json!([
                         {
@@ -445,7 +484,10 @@ mod tests {
     #[test]
     fn parse_nested_concatenations_into_pymodd() {
         assert_eq!(
-            ScriptsContentBuilder::new(&CategoriesToVariables::new(HashMap::new()))
+            ScriptsContentBuilder::new(
+                &CategoriesToVariables::new(HashMap::new()),
+                &Directory::new("root", "null", Vec::new())
+            )
                 .build_actions_content(&parse_actions(
                     &json!([
                         {
@@ -476,46 +518,49 @@ mod tests {
     #[test]
     fn parse_nested_if_statements_into_pymodd() {
         assert_eq!(
-            ScriptsContentBuilder::new(&CategoriesToVariables::new(HashMap::new()))
-                .build_actions_content(&parse_actions(
-                    json!([
-                         {
-                            "type": "condition",
-                            "conditions": [
-                                { "operandType": "boolean", "operator": "==" },
-                                true,
-                                true
-                            ],
-                            "then": [
-                                {
-                                    "type": "condition",
-                                    "conditions": [
-                                        { "operandType": "boolean", "operator": "==" },
-                                        true,
-                                        true
-                                    ],
-                                    "then": [
-                                        {
-                                            "type": "condition",
-                                            "conditions": [
-                                                { "operandType": "boolean", "operator": "==" },
-                                                true,
-                                                true
-                                            ],
-                                            "then": [],
-                                            "else": []
-                                        }
-                                    ],
-                                    "else": []
-                                   }
-                              ],
-                              "else": []
-                         }
-                    ])
-                    .as_array()
-                    .unwrap(),
-                ))
-                .as_str(),
+            ScriptsContentBuilder::new(
+                &CategoriesToVariables::new(HashMap::new()),
+                &Directory::new("root", "null", Vec::new())
+            )
+            .build_actions_content(&parse_actions(
+                json!([
+                     {
+                        "type": "condition",
+                        "conditions": [
+                            { "operandType": "boolean", "operator": "==" },
+                            true,
+                            true
+                        ],
+                        "then": [
+                            {
+                                "type": "condition",
+                                "conditions": [
+                                    { "operandType": "boolean", "operator": "==" },
+                                    true,
+                                    true
+                                ],
+                                "then": [
+                                    {
+                                        "type": "condition",
+                                        "conditions": [
+                                            { "operandType": "boolean", "operator": "==" },
+                                            true,
+                                            true
+                                        ],
+                                        "then": [],
+                                        "else": []
+                                    }
+                                ],
+                                "else": []
+                               }
+                          ],
+                          "else": []
+                     }
+                ])
+                .as_array()
+                .unwrap(),
+            ))
+            .as_str(),
             "if_else((True == True), [\n\
                 \tif_else((True == True), [\n\
     		        \t\tif_else((True == True), [\n\
@@ -537,7 +582,10 @@ mod tests {
     #[test]
     fn parse_nested_conditions_into_pymodd() {
         assert_eq!(
-            ScriptsContentBuilder::new(&CategoriesToVariables::new(HashMap::new()))
+            ScriptsContentBuilder::new(
+                &CategoriesToVariables::new(HashMap::new()),
+                &Directory::new("root", "null", Vec::new())
+            )
                 .build_actions_content(&parse_actions(
                     json!([
                          {
@@ -569,5 +617,40 @@ mod tests {
                 \t\n\
             ]),\n"
         );
+    }
+
+    #[test]
+    fn parse_run_script_action_into_pymodd() {
+        assert_eq!(
+            ScriptsContentBuilder::new(
+                &CategoriesToVariables::new(HashMap::new()),
+                &Directory::new(
+                    "root",
+                    "null",
+                    vec![DirectoryItem::Directory(Directory::new(
+                        "utils",
+                        "n3DhW3",
+                        vec![DirectoryItem::Script(Script {
+                            name: String::from("spawn boss"),
+                            key: String::from("If2aW3B"),
+                            triggers: Vec::new(),
+                            actions: Vec::new()
+                        })]
+                    ))]
+                )
+            )
+            .build_actions_content(&parse_actions(
+                json!([
+                     {
+                        "type": "runScript",
+                        "scriptName": "If2aW3B"
+                     }
+                ])
+                .as_array()
+                .unwrap(),
+            ))
+            .as_str(),
+            "run_script(SpawnBoss()),\n"
+        )
     }
 }

--- a/src/project_generator/utils/iterators/argument_values_iterator.rs
+++ b/src/project_generator/utils/iterators/argument_values_iterator.rs
@@ -67,6 +67,7 @@ pub enum ArgumentValueIterItem<'a> {
     Condition(Operation),
     Concatenation(Operation),
     Calculation(Operation),
+    ScriptKey(String),
     FunctionEnd,
 }
 
@@ -82,7 +83,13 @@ impl<'a> ArgumentValueIterItem<'a> {
                 }
             }
             ArgumentValue::Constant(constant) => ArgumentValueIterItem::Constant(&constant),
-            ArgumentValue::Value(value) => ArgumentValueIterItem::Value(&value),
+            ArgumentValue::Value(value) => {
+                if value.is_string() && argument.name.as_str() == "scriptName" {
+                    ArgumentValueIterItem::ScriptKey(value.as_str().unwrap().to_string())
+                } else {
+                    ArgumentValueIterItem::Value(&value)
+                }
+            }
             ArgumentValue::Actions(actions) => ArgumentValueIterItem::Actions(&actions),
         }
     }


### PR DESCRIPTION
- Users no longer need to define a `self.key` field for scripts
  - during pymodd project compilation, script and folder keys are automatically generated and stored
- The `run_script` action now accepts `Script` objects rather than script keys
  - before: `run_script('9Dw3BD')`
  - now: `run_script(SpawnBoss())`