### PR TITLE
Generate `keybindings` field only for unit types

### DIFF
--- a/pymodd/game.py
+++ b/pymodd/game.py
@@ -71,7 +71,9 @@ class Game(Base):
             entity_data['scripts'] = self.flatten_scripts_data(
                 entity_script.scripts)
 
-            # update entity keybindings
+            if entity_category != "UnitType":
+                continue
+            # update entity keybindings for unit types
             entity_keybindings_data = entity_data['controls']['abilities']
             unincluded_keys = list(entity_keybindings_data.keys())
             for (key, scripts) in entity_script.keybindings.items():

--- a/src/game_data/entity_types.rs
+++ b/src/game_data/entity_types.rs
@@ -1,4 +1,4 @@
-use std::collections::{hash_map, HashMap};
+use std::collections::HashMap;
 
 use heck::ToPascalCase;
 use serde_json::{Map, Value};
@@ -33,8 +33,18 @@ impl CategoriesToEntityTypes {
         }
     }
 
-    pub fn iter(&self) -> hash_map::Iter<&'static str, Vec<EntityType>> {
-        self.categories_to_entity_types.iter()
+    pub fn iter(&self) -> std::vec::IntoIter<(&&'static str, &Vec<EntityType>)> {
+        let mut categories_of_entity_types = self
+            .categories_to_entity_types
+            .iter()
+            .collect::<Vec<(&&'static str, &Vec<EntityType>)>>();
+        categories_of_entity_types.sort_by_key(|(category, _variables)| {
+            ["unitTypes", "itemTypes", "projectileTypes"]
+                .iter()
+                .position(|element| &element == category)
+                .unwrap()
+        });
+        categories_of_entity_types.into_iter()
     }
 }
 

--- a/src/project_generator/entity_scripts_file.rs
+++ b/src/project_generator/entity_scripts_file.rs
@@ -70,19 +70,26 @@ fn build_class_content_of_entity_type_in_category(
         "class {entity_type_class_name}(EntityScripts):\n\
             \tdef _build(self):\n\
                 \t\tself.entity_type = {category_class_name}.{}\n\
-                \t\tself.keybindings = {{\n\
                     {}\
-                \t\t\t\n\
-                \t\t}}\n\
                 \t\tself.scripts = [\n\
                     {}\
                 \t\t\t\n\
                 \t\t]\n",
         enum_name_of(&entity_type.name),
-        build_keybindings_dictionary_elements_for_entity_type(&entity_type, game_directory)
-            .into_iter()
-            .map(|element| format!("{}{element},\n", "\t".repeat(3)))
-            .collect::<String>(),
+        if category == "unitTypes" {
+            format!(
+                "\t\tself.keybindings = {{\n\
+                    {}\
+                \t\t\t\n\
+                \t\t}}\n",
+                build_keybindings_dictionary_elements_for_entity_type(&entity_type, game_directory)
+                    .into_iter()
+                    .map(|element| format!("{}{element},\n", "\t".repeat(3)))
+                    .collect::<String>()
+            )
+        } else {
+            String::new()
+        },
         build_directory_elements_for_entity_type(&entity_type)
             .into_iter()
             .map(|element| format!("{}{element}\n", "\t".repeat(3)))
@@ -285,6 +292,50 @@ mod tests {
                     \t\tself.scripts = [\n\
                         \t\t\tself.use_item(),\n\
                         \t\t\tself.stop_using_item(),\n\
+                        \t\t\t\n\
+                    \t\t]\n"
+        );
+    }
+
+    #[test]
+    fn item_type_entity_scripts_class() {
+        assert_eq!(
+            build_class_content_of_entity_type_in_category(
+                &EntityType {
+                    name: "sword".to_string(),
+                    directory: Directory::parse(&json!({})),
+                    keybindings: vec![]
+                },
+                "itemTypes",
+                &Directory::new("root", "null", vec![])
+            )
+            .as_str(),
+            "class Sword(EntityScripts):\n\
+                \tdef _build(self):\n\
+                    \t\tself.entity_type = ItemTypes.SWORD\n\
+                    \t\tself.scripts = [\n\
+                        \t\t\t\n\
+                    \t\t]\n"
+        );
+    }
+
+    #[test]
+    fn projectile_type_entity_scripts_class() {
+        assert_eq!(
+            build_class_content_of_entity_type_in_category(
+                &EntityType {
+                    name: "bullet".to_string(),
+                    directory: Directory::parse(&json!({})),
+                    keybindings: vec![]
+                },
+                "projectileTypes",
+                &Directory::new("root", "null", vec![])
+            )
+            .as_str(),
+            "class Bullet(EntityScripts):\n\
+                \tdef _build(self):\n\
+                    \t\tself.entity_type = ProjectileTypes.BULLET\n\
+                    \t\tself.scripts = [\n\
                         \t\t\t\n\
                     \t\t]\n"
         );


### PR DESCRIPTION
Item and projectile type `EntityScript` classes are not generated with a `keybindings` field