### PR TITLE
Parse operator directly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pymodd"
-version = "1.0.6"
+version = "1.0.7"
 description = "create and edit modd.io games in python"
 readme = "README.rst"
 requires-python = ">=3.8"


### PR DESCRIPTION
parse operators that are passed in as a string (usually on game templates):
```json
"items": [
  "-",
  1,
  1
]
```

are normally passed in as an object:
```json
{
  "operator": "-"
},
```